### PR TITLE
Remove branches key from branch_protection_rule

### DIFF
--- a/.github/workflows/4-add-branch-protections.yml
+++ b/.github/workflows/4-add-branch-protections.yml
@@ -11,8 +11,6 @@ on:
     types:
       - created
       - edited
-    branches:
-      - main
 
 # Reference: https://docs.github.com/en/actions/security-guides/automatic-token-authentication
 permissions:


### PR DESCRIPTION
This PR is suggested (commit) and generated (description except for this part and the link to the issue) by GitHub Copilot Chat.

### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->
This pull request addresses an issue in the `4-add-branch-protections.yml` GitHub Actions workflow file. The `branches` key was incorrectly placed under the `branch_protection_rule` key, which is not valid syntax.

### Changes
<!-- Describe the changes this pull request introduces. -->
The `branches` key has been removed from under the `branch_protection_rule` key in the `4-add-branch-protections.yml` file. This corrects the workflow syntax and ensures the workflow triggers correctly when a branch protection rule is created or edited.

<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes: #34

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
