### PR TITLE
Make merge script executable (#58)

### DIFF
--- a/.github/workflows/4-add-branch-protections.yml
+++ b/.github/workflows/4-add-branch-protections.yml
@@ -57,7 +57,9 @@ jobs:
           ref: ci # Important, as normally `branch_protection_rule` event won't grab other branches
 
       - name: Merge changes from origin main into ci
-        run: ./.github/script/merge-branch.sh
+        run: |
+          chmod +x ./.github/script/merge-branch.sh
+          ./.github/script/merge-branch.sh
         env:
           branch1: main
           branch2: ci


### PR DESCRIPTION
### Summary

The GitHub action workflow with name "Step 4, Add branch protections" errors out on the step titled "Merge changes from origin main into ci" with exit code 126 while trying to execute merge-branch.sh.


### Changes

Modifies the step named "Merge changes from origin main into ci" adding a statement to make the merge-branch.sh file executable prior to running it (chmod +x).

Closes:[[Bug] Step 4 workflow is not working #58 (https://github.com/skills/test-with-actions/issues/58)

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
