### PR TITLE
Increment actions/upload-artifact version from 3 to 4 to avoid deprecation

### DIFF
--- a/.github/steps/3-upload-test-reports.md
+++ b/.github/steps/3-upload-test-reports.md
@@ -30,7 +30,7 @@ To upload artifacts to the artifact storage, we can use an action built by GitHu
            npm install remark-cli remark-preset-lint-consistent vfile-reporter-json
            npx remark . --use remark-preset-lint-consistent --report vfile-reporter-json 2> remark-lint-report.json
 
-       - uses: actions/upload-artifact@v3
+       - uses: actions/upload-artifact@v4
          with:
            name: remark-lint-report
            path: remark-lint-report.json


### PR DESCRIPTION
### Summary
As per [this blog post](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/), version 3 of the upload-artifact action will be deprecated on November 30th 2024. This change increments the version used in this repository step from 3 to 4 to avoid deprecation.



### Changes
Use actions/upload-artifact@v4 instead of actions/upload-artifact@v3 in [3-upload-test-reports.md](.github/steps/3-upload-test-reports.md)


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes: [#63]

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
