### PR TITLE
Update 4-add-branch-protections.md

### DIFF
--- a/.github/steps/4-add-branch-protections.md
+++ b/.github/steps/4-add-branch-protections.md
@@ -15,7 +15,7 @@ Protected branches ensure that collaborators on your repository cannot make irre
 ### :keyboard: Activity: Add branch protections
 
 1. Go to **Branches** settings. You can navigate to that page manually by selecting the right-most tab in the top of the repository called **Settings** and then clicking **Branches**.
-1. Click **Add branch protection rule** under "Branch protection rules".
+1. Click **Add classic branch protection rule** under "Branch protection rules".
 1. Type `main` in **Branch name pattern**.
 1. Check **Require a pull request before merging**.
 1. Uncheck **Require approvals**.


### PR DESCRIPTION
This pull request includes a minor but important change to the instructions in the `.github/steps/4-add-branch-protections.md` file. The instruction to click **Add branch protection rule** under "Branch protection rules" has been updated to click **Add classic branch protection rule**. This change ensures that the instructions are accurate and up to date with the current user interface.