### PR TITLE
fix: update start-exercise workflow version to v0.8.1 to fix image issues in private repositories

### DIFF
--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -18,7 +18,7 @@ jobs:
     if: |
       !github.event.repository.is_template
     name: Start Exercise
-    uses: skills/exercise-toolkit/.github/workflows/start-exercise.yml@v0.8.0
+    uses: skills/exercise-toolkit/.github/workflows/start-exercise.yml@copilot/update-image-link-structure
     with:
       exercise-title: "Test with Actions"
       intro-message: "Protect your code with automated unit tests and coverage reports."

--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -18,7 +18,7 @@ jobs:
     if: |
       !github.event.repository.is_template
     name: Start Exercise
-    uses: skills/exercise-toolkit/.github/workflows/start-exercise.yml@copilot/update-image-link-structure
+    uses: skills/exercise-toolkit/.github/workflows/start-exercise.yml@v0.8.1
     with:
       exercise-title: "Test with Actions"
       intro-message: "Protect your code with automated unit tests and coverage reports."


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

Updated the start-exercise workflow version to v0.8.1 which contains a fix to a bug that was causing images in private repositories to be inaccessible

### Changes
<!-- Describe the changes this pull request introduces. -->


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes: https://github.com/skills/test-with-actions/issues/93

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
